### PR TITLE
Cập nhật quy trình xử lý đơn hàng và lịch sử hoạt động

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Báo cáo lỗi (Bug Report)
+description: Tạo báo cáo chi tiết về lỗi hoặc sự cố hệ thống
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Cảm ơn bạn đã dành thời gian báo cáo lỗi để giúp dự án hoàn thiện hơn!
+  - type: input
+    id: overview
+    attributes:
+      label: Tóm tắt lỗi
+      description: Một câu ngắn gọn mô tả vấn đề bạn gặp phải.
+      placeholder: Ví dụ: Nút thanh toán không hoạt động trên trang giỏ hàng
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Các bước tái hiện (Steps to Reproduce)
+      description: Vui lòng liệt kê các bước chi tiết để chúng tôi có thể tái hiện lại lỗi này.
+      placeholder: |
+        1. Truy cập vào trang...
+        2. Bấm vào...
+        3. Nhập thông tin...
+        4. Thấy lỗi...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Kết quả mong muốn (Expected Behavior)
+      description: Hệ thống đáng lẽ ra phải hoạt động như thế nào?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Kết quả thực tế (Actual Behavior)
+      description: Điều gì đã thực sự xảy ra? (Có thể đính kèm thông báo lỗi hoặc log)
+    validations:
+      required: true
+  - type: checkboxes
+    id: environment
+    attributes:
+      label: Môi trường xảy ra lỗi
+      description: Lỗi này xuất hiện trên môi trường nào?
+      options:
+        - label: Local (Môi trường phát triển)
+        - label: Staging / Test
+        - label: Production (Môi trường thực tế)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Đề xuất tính năng mới (Feature Request)
+description: Đề xuất ý tưởng hoặc tính năng mới cho dự án
+title: "[FEAT] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Chúng tôi rất hoan nghênh các ý tưởng đóng góp để cải tiến sản phẩm!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Vấn đề cần giải quyết
+      description: Tính năng này giải quyết vấn đề hoặc nhu cầu gì?
+      placeholder: Hiện tại khi làm việc X, người dùng gặp khó khăn vì...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Giải pháp đề xuất
+      description: Mô tả chi tiết về cách tính năng mới nên hoạt động.
+      placeholder: Bổ sung thêm chức năng/giao diện cho phép...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Các giải pháp thay thế đã cân nhắc (Tùy chọn)
+      description: Có giải pháp nào khác mà bạn đã nghĩ tới không?

--- a/.github/ISSUE_TEMPLATE/update_request.yml
+++ b/.github/ISSUE_TEMPLATE/update_request.yml
@@ -1,0 +1,32 @@
+name: Đề xuất cập nhật/cải tiến (Update Request)
+description: Đề xuất thay đổi, nâng cấp hoặc tối ưu hóa một chức năng hiện có
+title: "[UPDATE] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Sử dụng mẫu này để đề xuất cải tiến hoặc thay đổi cho các chức năng đang có trong hệ thống.
+  - type: input
+    id: feature
+    attributes:
+      label: Chức năng cần cập nhật
+      description: Tên chức năng hoặc module bạn muốn đề xuất thay đổi là gì?
+      placeholder: Ví dụ: Quy trình thanh toán đơn hàng hoặc Giao diện danh sách sản phẩm
+    validations:
+      required: true
+  - type: textarea
+    id: current_state
+    attributes:
+      label: Hiện trạng hiện tại
+      description: Chức năng này hiện tại đang hoạt động như thế nào? Có hạn chế hay bất cập gì không?
+      placeholder: Hiện tại hệ thống đang xử lý...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_outcome
+    attributes:
+      label: Kết quả mong đợi
+      description: Sau khi cập nhật, chức năng này nên hoạt động hoặc hiển thị ra sao? Mang lại lợi ích gì?
+      placeholder: Mong muốn hệ thống sẽ hỗ trợ/tối ưu...
+    validations:
+      required: true

--- a/src/main/java/group36/controller/UserOrderController.java
+++ b/src/main/java/group36/controller/UserOrderController.java
@@ -214,13 +214,18 @@ public class UserOrderController extends HttpServlet {
                 return;
             }
 
-            if (!"pending".equals(order.getStatus())) {
-                request.getSession().setAttribute("errorMessage", "Chỉ có thể hủy đơn hàng đang chờ xác nhận");
+            String reason = request.getParameter("reason");
+            if (reason == null || reason.trim().isEmpty()) {
+                reason = "Người dùng hủy đơn hàng";
+            }
+
+            boolean updated = orderService.cancelOrderByUser(orderId, user.getId(), reason);
+
+            if (!updated) {
+                request.getSession().setAttribute("errorMessage", "Không thể hủy đơn hàng (trạng thái không cho phép)");
                 response.sendRedirect(request.getContextPath() + "/ho-so/don-hang/chi-tiet?id=" + orderId);
                 return;
             }
-
-            orderService.updateOrderStatus(orderId, "cancelled");
 
             try {
                 notificationService.createOrderCancelledNotification(order);
@@ -351,13 +356,13 @@ public class UserOrderController extends HttpServlet {
                 return;
             }
 
-            if (!"shipping".equals(order.getStatus())) {
-                request.getSession().setAttribute("errorMessage", "Chỉ xác nhận nhận hàng khi đơn đang giao");
+            boolean updated = orderService.confirmReceivedByUser(orderId, user.getId());
+
+            if (!updated) {
+                request.getSession().setAttribute("errorMessage", "Không thể xác nhận nhận hàng (trạng thái không cho phép)");
                 response.sendRedirect(request.getContextPath() + "/ho-so/don-hang/chi-tiet?id=" + orderId);
                 return;
             }
-
-            orderService.updateOrderStatus(orderId, "completed");
 
             request.getSession().setAttribute("successMessage",
                     "Xác nhận nhận hàng thành công! Bạn có thể đánh giá sản phẩm.");

--- a/src/main/java/group36/controller/admin/AdminOrderController.java
+++ b/src/main/java/group36/controller/admin/AdminOrderController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import jakarta.servlet.annotation.*;
 import group36.model.Order;
+import group36.model.User;
 import group36.service.OrderService;
 
 import java.io.IOException;
@@ -51,6 +52,8 @@ public class AdminOrderController extends HttpServlet {
         try {
             if (pathInfo != null && pathInfo.equals("/update-status")) {
                 updateOrderStatus(request, response);
+            } else if (pathInfo != null && pathInfo.equals("/update-note")) {
+                updateAdminNote(request, response);
             } else {
                 response.sendError(HttpServletResponse.SC_NOT_FOUND);
             }
@@ -159,7 +162,11 @@ public class AdminOrderController extends HttpServlet {
                 return;
             }
 
-            request.setAttribute("order", orderOpt.get());
+            Order order = orderOpt.get();
+            orderService.loadOrderDetailsForAdmin(order);
+            
+            request.setAttribute("order", order);
+            request.setAttribute("allowedStatuses", Order.getAllowedNextStatuses(order.getStatus()));
             request.getRequestDispatcher("/admin/order-detail.jsp").forward(request, response);
         } catch (NumberFormatException e) {
             HttpSession session = request.getSession();
@@ -183,18 +190,48 @@ public class AdminOrderController extends HttpServlet {
 
         try {
             int orderId = Integer.parseInt(orderIdParam);
+            String note = request.getParameter("note");
+            
+            HttpSession session = request.getSession();
+            User admin = (User) session.getAttribute("auth");
+            Integer adminId = admin != null ? admin.getId() : null;
 
-            if (!isValidStatus(newStatus)) {
-                out.print("{\"success\": false, \"message\": \"Trạng thái không hợp lệ\"}");
-                return;
-            }
-
-            boolean updated = orderService.updateOrderStatus(orderId, newStatus);
+            boolean updated = orderService.updateOrderStatus(orderId, newStatus, "admin", adminId, note);
 
             if (updated) {
                 out.print("{\"success\": true, \"message\": \"Cập nhật trạng thái thành công\"}");
             } else {
                 out.print("{\"success\": false, \"message\": \"Không thể cập nhật trạng thái\"}");
+            }
+        } catch (IllegalStateException e) {
+            out.print("{\"success\": false, \"message\": \"" + e.getMessage() + "\"}");
+        } catch (NumberFormatException e) {
+            out.print("{\"success\": false, \"message\": \"ID đơn hàng không hợp lệ\"}");
+        }
+    }
+
+    private void updateAdminNote(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        PrintWriter out = response.getWriter();
+
+        String orderIdParam = request.getParameter("orderId");
+        String adminNote = request.getParameter("adminNote");
+
+        if (orderIdParam == null) {
+            out.print("{\"success\": false, \"message\": \"Thiếu ID đơn hàng\"}");
+            return;
+        }
+
+        try {
+            int orderId = Integer.parseInt(orderIdParam);
+            group36.dao.OrderDAO dao = new group36.dao.OrderDAO();
+            int result = dao.updateAdminNote(orderId, adminNote);
+
+            if (result > 0) {
+                out.print("{\"success\": true, \"message\": \"Cập nhật ghi chú thành công\"}");
+            } else {
+                out.print("{\"success\": false, \"message\": \"Không thể cập nhật ghi chú\"}");
             }
         } catch (NumberFormatException e) {
             out.print("{\"success\": false, \"message\": \"ID đơn hàng không hợp lệ\"}");
@@ -207,6 +244,11 @@ public class AdminOrderController extends HttpServlet {
                 status.equals("processing") ||
                 status.equals("shipping") ||
                 status.equals("completed") ||
-                status.equals("cancelled");
+                status.equals("cancelled") ||
+                status.equals("payment_expired") ||
+                status.equals("delivery_failed") ||
+                status.equals("returned") ||
+                status.equals("refunded") ||
+                status.equals("cancelled_by_admin");
     }
 }

--- a/src/main/java/group36/dao/OrderDAO.java
+++ b/src/main/java/group36/dao/OrderDAO.java
@@ -41,6 +41,11 @@ public class OrderDAO extends BaseDao {
                         } catch (SQLException e) {
                         }
 
+                        try {
+                                order.setAdminNote(rs.getString("admin_note"));
+                        } catch (SQLException e) {
+                        }
+
                         return order;
                 }
         }
@@ -98,15 +103,16 @@ public class OrderDAO extends BaseDao {
         }
 
         public int insert(Order order) {
-                String sql = "INSERT INTO orders (user_id, address_id, payment_method_id, status, note, shipping_fee, total_price) "
+                String sql = "INSERT INTO orders (user_id, address_id, payment_method_id, status, note, admin_note, shipping_fee, total_price) "
                                 +
-                                "VALUES (:userId, :addressId, :paymentMethodId, :status, :note, :shippingFee, :totalPrice)";
+                                "VALUES (:userId, :addressId, :paymentMethodId, :status, :note, :adminNote, :shippingFee, :totalPrice)";
                 return get().withHandle(handle -> handle.createUpdate(sql)
                                 .bind("userId", order.getUserId())
                                 .bind("addressId", order.getAddressId())
                                 .bind("paymentMethodId", order.getPaymentMethodId())
                                 .bind("status", order.getStatus())
                                 .bind("note", order.getNote())
+                                .bind("adminNote", order.getAdminNote())
                                 .bind("shippingFee", order.getShippingFee())
                                 .bind("totalPrice", order.getTotalPrice())
                                 .executeAndReturnGeneratedKeys("id")
@@ -115,9 +121,9 @@ public class OrderDAO extends BaseDao {
         }
 
         public int insertGuestOrder(Order order) {
-                String sql = "INSERT INTO orders (user_id, address_id, payment_method_id, status, note, " +
+                String sql = "INSERT INTO orders (user_id, address_id, payment_method_id, status, note, admin_note, " +
                                 "shipping_fee, total_price, guest_email, guest_name, guest_phone) " +
-                                "VALUES (NULL, :addressId, :paymentMethodId, :status, :note, :shippingFee, :totalPrice, "
+                                "VALUES (NULL, :addressId, :paymentMethodId, :status, :note, :adminNote, :shippingFee, :totalPrice, "
                                 +
                                 ":guestEmail, :guestName, :guestPhone)";
                 return get().withHandle(handle -> handle.createUpdate(sql)
@@ -125,6 +131,7 @@ public class OrderDAO extends BaseDao {
                                 .bind("paymentMethodId", order.getPaymentMethodId())
                                 .bind("status", order.getStatus())
                                 .bind("note", order.getNote())
+                                .bind("adminNote", order.getAdminNote())
                                 .bind("shippingFee", order.getShippingFee())
                                 .bind("totalPrice", order.getTotalPrice())
                                 .bind("guestEmail", order.getGuestEmail())
@@ -140,6 +147,14 @@ public class OrderDAO extends BaseDao {
                 return get().withHandle(handle -> handle.createUpdate(sql)
                                 .bind("id", orderId)
                                 .bind("status", status)
+                                .execute());
+        }
+
+        public int updateAdminNote(int orderId, String adminNote) {
+                String sql = "UPDATE orders SET admin_note = :adminNote WHERE id = :id";
+                return get().withHandle(handle -> handle.createUpdate(sql)
+                                .bind("id", orderId)
+                                .bind("adminNote", adminNote)
                                 .execute());
         }
 

--- a/src/main/java/group36/dao/OrderStatusHistoryDAO.java
+++ b/src/main/java/group36/dao/OrderStatusHistoryDAO.java
@@ -1,0 +1,63 @@
+package group36.dao;
+
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import group36.model.OrderStatusHistory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+
+public class OrderStatusHistoryDAO extends BaseDao {
+
+    private static class OrderStatusHistoryMapper implements RowMapper<OrderStatusHistory> {
+        @Override
+        public OrderStatusHistory map(ResultSet rs, StatementContext ctx) throws SQLException {
+            OrderStatusHistory history = new OrderStatusHistory();
+            history.setId(rs.getInt("id"));
+            history.setOrderId(rs.getInt("order_id"));
+            history.setOldStatus(rs.getString("old_status"));
+            history.setNewStatus(rs.getString("new_status"));
+            history.setChangedBy(rs.getString("changed_by"));
+            
+            int changedById = rs.getInt("changed_by_id");
+            history.setChangedById(rs.wasNull() ? null : changedById);
+            
+            history.setNote(rs.getString("note"));
+            history.setCreatedAt(rs.getTimestamp("created_at"));
+            return history;
+        }
+    }
+
+    public int insert(OrderStatusHistory history) {
+        String sql = "INSERT INTO order_status_history (order_id, old_status, new_status, changed_by, changed_by_id, note) " +
+                     "VALUES (:orderId, :oldStatus, :newStatus, :changedBy, :changedById, :note)";
+        return get().withHandle(handle -> handle.createUpdate(sql)
+                .bind("orderId", history.getOrderId())
+                .bind("oldStatus", history.getOldStatus())
+                .bind("newStatus", history.getNewStatus())
+                .bind("changedBy", history.getChangedBy())
+                .bind("changedById", history.getChangedById())
+                .bind("note", history.getNote())
+                .executeAndReturnGeneratedKeys("id")
+                .mapTo(Integer.class)
+                .one());
+    }
+
+    public List<OrderStatusHistory> findByOrderId(int orderId) {
+        String sql = "SELECT * FROM order_status_history WHERE order_id = :orderId ORDER BY created_at DESC";
+        return get().withHandle(handle -> handle.createQuery(sql)
+                .bind("orderId", orderId)
+                .map(new OrderStatusHistoryMapper())
+                .list());
+    }
+
+    public Optional<OrderStatusHistory> findLatestByOrderId(int orderId) {
+        String sql = "SELECT * FROM order_status_history WHERE order_id = :orderId ORDER BY created_at DESC LIMIT 1";
+        return get().withHandle(handle -> handle.createQuery(sql)
+                .bind("orderId", orderId)
+                .map(new OrderStatusHistoryMapper())
+                .findOne());
+    }
+}

--- a/src/main/java/group36/model/Order.java
+++ b/src/main/java/group36/model/Order.java
@@ -52,6 +52,7 @@ public class Order implements Serializable {
         // From pending
         Set<String> pendingNext = new HashSet<>();
         pendingNext.add(STATUS_CONFIRMED);
+        pendingNext.add(STATUS_PROCESSING);
         pendingNext.add(STATUS_CANCELLED);
         pendingNext.add(STATUS_CANCELLED_BY_ADMIN);
         pendingNext.add(STATUS_PAYMENT_EXPIRED);
@@ -60,6 +61,7 @@ public class Order implements Serializable {
         // From confirmed
         Set<String> confirmedNext = new HashSet<>();
         confirmedNext.add(STATUS_PROCESSING);
+        confirmedNext.add(STATUS_SHIPPING);
         confirmedNext.add(STATUS_CANCELLED_BY_ADMIN);
         ALLOWED_TRANSITIONS.put(STATUS_CONFIRMED, confirmedNext);
 

--- a/src/main/java/group36/model/Order.java
+++ b/src/main/java/group36/model/Order.java
@@ -27,6 +27,8 @@ public class Order implements Serializable {
     private User user;
     private List<OrderDetail> orderDetails;
     private Payment latestPayment;
+    private String adminNote;
+    private List<OrderStatusHistory> statusHistory;
 
     public static final String STATUS_PENDING = "pending";
     public static final String STATUS_CONFIRMED = "confirmed";
@@ -34,6 +36,11 @@ public class Order implements Serializable {
     public static final String STATUS_SHIPPING = "shipping";
     public static final String STATUS_DELIVERED = "completed";
     public static final String STATUS_CANCELLED = "cancelled";
+    public static final String STATUS_PAYMENT_EXPIRED = "payment_expired";
+    public static final String STATUS_DELIVERY_FAILED = "delivery_failed";
+    public static final String STATUS_RETURNED = "returned";
+    public static final String STATUS_REFUNDED = "refunded";
+    public static final String STATUS_CANCELLED_BY_ADMIN = "cancelled_by_admin";
 
     public static final double FREE_SHIPPING_THRESHOLD = 100000;
     public static final double STANDARD_SHIPPING_FEE = 30000;
@@ -98,6 +105,22 @@ public class Order implements Serializable {
 
     public void setNote(String note) {
         this.note = note;
+    }
+
+    public String getAdminNote() {
+        return adminNote;
+    }
+
+    public void setAdminNote(String adminNote) {
+        this.adminNote = adminNote;
+    }
+
+    public List<OrderStatusHistory> getStatusHistory() {
+        return statusHistory;
+    }
+
+    public void setStatusHistory(List<OrderStatusHistory> statusHistory) {
+        this.statusHistory = statusHistory != null ? statusHistory : new ArrayList<>();
     }
 
     public double getShippingFee() {
@@ -301,6 +324,16 @@ public class Order implements Serializable {
                 return "Hoàn thành";
             case STATUS_CANCELLED:
                 return "Đã hủy";
+            case STATUS_PAYMENT_EXPIRED:
+                return "Thanh toán hết hạn";
+            case STATUS_DELIVERY_FAILED:
+                return "Giao thất bại";
+            case STATUS_RETURNED:
+                return "Hoàn hàng";
+            case STATUS_REFUNDED:
+                return "Hoàn tiền";
+            case STATUS_CANCELLED_BY_ADMIN:
+                return "Hủy bởi admin";
             default:
                 return status;
         }
@@ -318,7 +351,15 @@ public class Order implements Serializable {
             case STATUS_DELIVERED:
                 return "badge-success";
             case STATUS_CANCELLED:
+            case STATUS_PAYMENT_EXPIRED:
+            case STATUS_CANCELLED_BY_ADMIN:
                 return "badge-danger";
+            case STATUS_DELIVERY_FAILED:
+                return "badge-warning";
+            case STATUS_RETURNED:
+                return "badge-info";
+            case STATUS_REFUNDED:
+                return "badge-secondary";
             default:
                 return "badge-secondary";
         }

--- a/src/main/java/group36/model/Order.java
+++ b/src/main/java/group36/model/Order.java
@@ -3,7 +3,11 @@ package group36.model;
 import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class Order implements Serializable {
     private int id;
@@ -42,6 +46,58 @@ public class Order implements Serializable {
     public static final String STATUS_REFUNDED = "refunded";
     public static final String STATUS_CANCELLED_BY_ADMIN = "cancelled_by_admin";
 
+    public static final Map<String, Set<String>> ALLOWED_TRANSITIONS = new HashMap<>();
+
+    static {
+        // From pending
+        Set<String> pendingNext = new HashSet<>();
+        pendingNext.add(STATUS_CONFIRMED);
+        pendingNext.add(STATUS_CANCELLED);
+        pendingNext.add(STATUS_CANCELLED_BY_ADMIN);
+        pendingNext.add(STATUS_PAYMENT_EXPIRED);
+        ALLOWED_TRANSITIONS.put(STATUS_PENDING, pendingNext);
+
+        // From confirmed
+        Set<String> confirmedNext = new HashSet<>();
+        confirmedNext.add(STATUS_PROCESSING);
+        confirmedNext.add(STATUS_CANCELLED_BY_ADMIN);
+        ALLOWED_TRANSITIONS.put(STATUS_CONFIRMED, confirmedNext);
+
+        // From processing
+        Set<String> processingNext = new HashSet<>();
+        processingNext.add(STATUS_SHIPPING);
+        processingNext.add(STATUS_CANCELLED_BY_ADMIN);
+        ALLOWED_TRANSITIONS.put(STATUS_PROCESSING, processingNext);
+
+        // From shipping
+        Set<String> shippingNext = new HashSet<>();
+        shippingNext.add(STATUS_DELIVERED);
+        shippingNext.add(STATUS_DELIVERY_FAILED);
+        ALLOWED_TRANSITIONS.put(STATUS_SHIPPING, shippingNext);
+
+        // From delivered
+        Set<String> deliveredNext = new HashSet<>();
+        deliveredNext.add(STATUS_RETURNED);
+        ALLOWED_TRANSITIONS.put(STATUS_DELIVERED, deliveredNext);
+        
+        // From delivery_failed
+        Set<String> deliveryFailedNext = new HashSet<>();
+        deliveryFailedNext.add(STATUS_RETURNED);
+        deliveryFailedNext.add(STATUS_REFUNDED);
+        ALLOWED_TRANSITIONS.put(STATUS_DELIVERY_FAILED, deliveryFailedNext);
+
+        // From returned
+        Set<String> returnedNext = new HashSet<>();
+        returnedNext.add(STATUS_REFUNDED);
+        ALLOWED_TRANSITIONS.put(STATUS_RETURNED, returnedNext);
+
+        // Terminal states
+        ALLOWED_TRANSITIONS.put(STATUS_CANCELLED, new HashSet<>());
+        ALLOWED_TRANSITIONS.put(STATUS_CANCELLED_BY_ADMIN, new HashSet<>());
+        ALLOWED_TRANSITIONS.put(STATUS_PAYMENT_EXPIRED, new HashSet<>());
+        ALLOWED_TRANSITIONS.put(STATUS_REFUNDED, new HashSet<>());
+    }
+
     public static final double FREE_SHIPPING_THRESHOLD = 100000;
     public static final double STANDARD_SHIPPING_FEE = 30000;
 
@@ -57,6 +113,23 @@ public class Order implements Serializable {
         this.totalPrice = totalPrice;
         this.status = STATUS_PENDING;
         this.orderDetails = new ArrayList<>();
+    }
+
+    public static boolean isTransitionAllowed(String currentStatus, String newStatus) {
+        if (currentStatus == null || newStatus == null) return false;
+        if (currentStatus.equals(newStatus)) return true;
+        Set<String> allowed = ALLOWED_TRANSITIONS.get(currentStatus);
+        return allowed != null && allowed.contains(newStatus);
+    }
+
+    public static Set<String> getAllowedNextStatuses(String currentStatus) {
+        Set<String> allowed = ALLOWED_TRANSITIONS.get(currentStatus);
+        return allowed != null ? allowed : new HashSet<>();
+    }
+
+    public static boolean isTerminalStatus(String status) {
+        Set<String> allowed = ALLOWED_TRANSITIONS.get(status);
+        return allowed == null || allowed.isEmpty();
     }
 
     public int getId() {

--- a/src/main/java/group36/model/OrderStatusHistory.java
+++ b/src/main/java/group36/model/OrderStatusHistory.java
@@ -1,0 +1,76 @@
+package group36.model;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+
+public class OrderStatusHistory implements Serializable {
+    private int id;
+    private int orderId;
+    private String oldStatus;
+    private String newStatus;
+    private String changedBy; // "admin", "user", "system"
+    private Integer changedById;
+    private String note;
+    private Timestamp createdAt;
+
+    public OrderStatusHistory() {
+    }
+
+    public int getId() { return id; }
+    public void setId(int id) { this.id = id; }
+
+    public int getOrderId() { return orderId; }
+    public void setOrderId(int orderId) { this.orderId = orderId; }
+
+    public String getOldStatus() { return oldStatus; }
+    public void setOldStatus(String oldStatus) { this.oldStatus = oldStatus; }
+
+    public String getNewStatus() { return newStatus; }
+    public void setNewStatus(String newStatus) { this.newStatus = newStatus; }
+
+    public String getChangedBy() { return changedBy; }
+    public void setChangedBy(String changedBy) { this.changedBy = changedBy; }
+
+    public Integer getChangedById() { return changedById; }
+    public void setChangedById(Integer changedById) { this.changedById = changedById; }
+
+    public String getNote() { return note; }
+    public void setNote(String note) { this.note = note; }
+
+    public Timestamp getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Timestamp createdAt) { this.createdAt = createdAt; }
+
+    public String getChangedByText() {
+        if ("admin".equals(changedBy)) return "Admin";
+        if ("user".equals(changedBy)) return "Khách hàng";
+        if ("system".equals(changedBy)) return "Hệ thống";
+        return changedBy;
+    }
+
+    public String getOldStatusText() {
+        if (oldStatus == null) return "Mới tạo";
+        return getStatusText(oldStatus);
+    }
+
+    public String getNewStatusText() {
+        return getStatusText(newStatus);
+    }
+
+    private String getStatusText(String status) {
+        if (status == null) return "";
+        switch (status) {
+            case Order.STATUS_PENDING: return "Chờ xác nhận";
+            case Order.STATUS_CONFIRMED: return "Đang xử lý";
+            case Order.STATUS_PROCESSING: return "Đang xử lý";
+            case Order.STATUS_SHIPPING: return "Đang giao";
+            case Order.STATUS_DELIVERED: return "Hoàn thành";
+            case Order.STATUS_CANCELLED: return "Đã hủy";
+            case Order.STATUS_PAYMENT_EXPIRED: return "Thanh toán hết hạn";
+            case Order.STATUS_DELIVERY_FAILED: return "Giao thất bại";
+            case Order.STATUS_RETURNED: return "Hoàn hàng";
+            case Order.STATUS_REFUNDED: return "Hoàn tiền";
+            case Order.STATUS_CANCELLED_BY_ADMIN: return "Hủy bởi admin";
+            default: return status;
+        }
+    }
+}

--- a/src/main/java/group36/service/OrderService.java
+++ b/src/main/java/group36/service/OrderService.java
@@ -24,6 +24,7 @@ public class OrderService {
     private final AdminNotificationService adminNotificationService;
     private final UserDAO userDAO;
     private final FlashSaleDAO flashSaleDAO;
+    private final OrderStatusHistoryDAO orderStatusHistoryDAO;
 
     public static final double FREE_SHIPPING_THRESHOLD = 100000;
     public static final double STANDARD_SHIPPING_FEE = 30000;
@@ -42,6 +43,7 @@ public class OrderService {
         this.adminNotificationService = new AdminNotificationService();
         this.userDAO = new UserDAO();
         this.flashSaleDAO = new FlashSaleDAO();
+        this.orderStatusHistoryDAO = new OrderStatusHistoryDAO();
     }
 
     public double calculateShippingFee(double subtotal) {
@@ -432,9 +434,55 @@ public class OrderService {
         return orderDAO.findAllPaginated(page, size);
     }
 
+    @Deprecated
     public boolean updateOrderStatus(int orderId, String status) {
-        int result = orderDAO.updateStatus(orderId, status);
-        return result > 0;
+        return updateOrderStatus(orderId, status, "system", null, null);
+    }
+
+    public boolean updateOrderStatus(int orderId, String newStatus, String changedBy, Integer changedById, String note) {
+        Optional<Order> orderOpt = orderDAO.findById(orderId);
+        if (orderOpt.isEmpty()) {
+            return false;
+        }
+        Order order = orderOpt.get();
+        String oldStatus = order.getStatus();
+
+        if (!Order.isTransitionAllowed(oldStatus, newStatus)) {
+            throw new IllegalStateException("Không thể chuyển trạng thái từ " + oldStatus + " sang " + newStatus);
+        }
+
+        boolean updated = orderDAO.updateStatus(orderId, newStatus) > 0;
+        if (updated) {
+            OrderStatusHistory history = new OrderStatusHistory();
+            history.setOrderId(orderId);
+            history.setOldStatus(oldStatus);
+            history.setNewStatus(newStatus);
+            history.setChangedBy(changedBy);
+            history.setChangedById(changedById);
+            history.setNote(note);
+            orderStatusHistoryDAO.insert(history);
+        }
+        return updated;
+    }
+
+    public boolean cancelOrderByUser(int orderId, int userId, String reason) {
+        Optional<Order> orderOpt = orderDAO.findById(orderId);
+        if (orderOpt.isEmpty() || !orderOpt.get().getUserId().equals(userId)) {
+            return false;
+        }
+        return updateOrderStatus(orderId, Order.STATUS_CANCELLED, "user", userId, reason);
+    }
+
+    public boolean cancelOrderByAdmin(int orderId, int adminId, String reason) {
+        return updateOrderStatus(orderId, Order.STATUS_CANCELLED_BY_ADMIN, "admin", adminId, reason);
+    }
+
+    public boolean confirmReceivedByUser(int orderId, int userId) {
+        Optional<Order> orderOpt = orderDAO.findById(orderId);
+        if (orderOpt.isEmpty() || !orderOpt.get().getUserId().equals(userId)) {
+            return false;
+        }
+        return updateOrderStatus(orderId, Order.STATUS_DELIVERED, "user", userId, "Khách hàng xác nhận đã nhận hàng");
     }
 
     public int countOrders() {
@@ -455,6 +503,9 @@ public class OrderService {
         addressDAO.findById(order.getAddressId()).ifPresent(order::setAddress);
         paymentMethodDAO.findById(order.getPaymentMethodId()).ifPresent(order::setPaymentMethod);
         paymentDAO.findLatestByOrderId(order.getId()).ifPresent(order::setLatestPayment);
+
+        List<OrderStatusHistory> history = orderStatusHistoryDAO.findByOrderId(order.getId());
+        order.setStatusHistory(history);
 
         if (!order.isGuestOrder() && order.getUserId() != null) {
             userDAO.findById(order.getUserId()).ifPresent(order::setUser);
@@ -545,6 +596,9 @@ public class OrderService {
         addressDAO.findById(order.getAddressId()).ifPresent(order::setAddress);
         paymentMethodDAO.findById(order.getPaymentMethodId()).ifPresent(order::setPaymentMethod);
         paymentDAO.findLatestByOrderId(order.getId()).ifPresent(order::setLatestPayment);
+
+        List<OrderStatusHistory> history = orderStatusHistoryDAO.findByOrderId(order.getId());
+        order.setStatusHistory(history);
     }
 
     public double getTotalRevenue() {

--- a/src/main/webapp/admin/order-detail.jsp
+++ b/src/main/webapp/admin/order-detail.jsp
@@ -232,6 +232,62 @@
                                             </div>
                                         </div>
                                     </div>
+
+                                    <div class="card">
+                                        <div class="card-header">
+                                            <h3 class="card-title"><i class="fas fa-list-ul"
+                                                    style="color:#0ea5e9;margin-right:6px;"></i> Nhật ký hoạt động</h3>
+                                        </div>
+                                        <div class="card-body" style="padding:0;">
+                                            <c:choose>
+                                                <c:when test="${not empty order.statusHistory}">
+                                                    <table class="admin-table">
+                                                        <thead>
+                                                            <tr>
+                                                                <th style="width:160px;">Thời gian</th>
+                                                                <th style="width:140px;">Người thực hiện</th>
+                                                                <th style="width:200px;">Hành động</th>
+                                                                <th>Ghi chú</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            <c:forEach var="history" items="${order.statusHistory}">
+                                                                <tr>
+                                                                    <td>
+                                                                        <span class="info-value" style="font-size: 0.9em; color: #64748b;"><fmt:formatDate value="${history.createdAt}" pattern="dd/MM/yyyy HH:mm:ss" /></span>
+                                                                    </td>
+                                                                    <td>
+                                                                        <span style="font-size: 0.85em; padding: 4px 8px; border-radius: 4px; font-weight: 500; ${history.changedBy == 'admin' ? 'background:#e0e7ff;color:#4338ca;' : (history.changedBy == 'user' ? 'background:#dcfce7;color:#15803d;' : 'background:#f1f5f9;color:#475569;')}">
+                                                                            ${history.changedByText}
+                                                                        </span>
+                                                                    </td>
+                                                                    <td>
+                                                                        Chuyển sang <strong>${history.newStatusText}</strong>
+                                                                    </td>
+                                                                    <td>
+                                                                        <c:choose>
+                                                                            <c:when test="${not empty history.note}">
+                                                                                <span style="color: #334155;">${history.note}</span>
+                                                                            </c:when>
+                                                                            <c:otherwise>
+                                                                                <span class="empty-val">—</span>
+                                                                            </c:otherwise>
+                                                                        </c:choose>
+                                                                    </td>
+                                                                </tr>
+                                                            </c:forEach>
+                                                        </tbody>
+                                                    </table>
+                                                </c:when>
+                                                <c:otherwise>
+                                                    <div style="padding:24px;text-align:center;color:#94a3b8; font-style: italic;">
+                                                        Chưa có nhật ký hoạt động nào.
+                                                    </div>
+                                                </c:otherwise>
+                                            </c:choose>
+                                        </div>
+                                    </div>
+
                                     <div class="card">
                                         <div class="card-header">
                                             <h3 class="card-title"><i class="fas fa-shopping-basket"


### PR DESCRIPTION
**Tình trạng và vấn đề:**
- Admin có thể tự do đổi trạng thái đơn hàng lung tung qua một cái dropdown (ví dụ đơn đang "Chờ xác nhận" có thể nhảy thẳng sang "Hoàn thành" hoặc ngược lại), rất dễ bấm nhầm.
- Hệ thống không lưu lại lịch sử, nên khi xảy ra vấn đề không biết ai (user hay admin) đã đổi trạng thái và đổi vào lúc nào.
- Admin không có chỗ để ghi chú lại thông tin riêng cho từng đơn hàng khi cần.

**Đã giải quyết:**
- Chuẩn hóa luồng đi của đơn hàng: Bắt buộc phải đi theo đúng thứ tự (Chờ xác nhận -> Đã xác nhận -> Đang đóng gói -> Đang giao -> Hoàn thành). Giao diện admin chỉ hiện nút bấm chuyển sang bước tiếp theo hợp lệ chứ không cho chọn tự do nữa.
- Thêm các trạng thái thực tế: bổ sung thêm các trường hợp hay gặp như Giao thất bại, Hoàn hàng, Hết hạn thanh toán, Hủy bởi admin.
- Có lịch sử theo dõi: Thêm bảng "Nhật ký hoạt động" trong chi tiết đơn hàng bên trang Admin để xem rõ thời gian, ai là người đổi trạng thái và ghi chú kèm theo.