### PR TITLE
fix(order): thêm transaction cho xử lý đặt hàng (#75)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     compileOnly 'jakarta.servlet:jakarta.servlet-api:6.0.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
+    testImplementation 'com.h2database:h2:2.2.224'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
 
     implementation 'org.jdbi:jdbi3-core:3.48.0'
     implementation 'com.mysql:mysql-connector-j:9.3.0'

--- a/src/main/java/group36/dao/AddressDAO.java
+++ b/src/main/java/group36/dao/AddressDAO.java
@@ -54,9 +54,13 @@ public class AddressDAO extends BaseDao {
     }
 
     public int insert(Address address) {
+        return get().withHandle(h -> insertWithHandle(h, address));
+    }
+
+    public int insertWithHandle(org.jdbi.v3.core.Handle h, Address address) {
         String sql = "INSERT INTO address (user_id, receiver, phone, address_detail, district, city, is_default) " +
                 "VALUES (:userId, :receiver, :phone, :addressDetail, :district, :city, :isDefault)";
-        return get().withHandle(handle -> handle.createUpdate(sql)
+        return h.createUpdate(sql)
                 .bind("userId", address.getUserId())
                 .bind("receiver", address.getReceiver())
                 .bind("phone", address.getPhone())
@@ -66,7 +70,7 @@ public class AddressDAO extends BaseDao {
                 .bind("isDefault", address.isDefault())
                 .executeAndReturnGeneratedKeys("id")
                 .mapTo(Integer.class)
-                .one());
+                .one();
     }
 
     public int update(Address address) {

--- a/src/main/java/group36/dao/BaseDao.java
+++ b/src/main/java/group36/dao/BaseDao.java
@@ -1,33 +1,11 @@
 package group36.dao;
 
-import com.mysql.cj.jdbc.MysqlDataSource;
 import org.jdbi.v3.core.Jdbi;
-
-import java.sql.SQLException;
 
 public abstract class BaseDao {
 
-    Jdbi jdbi;
-
     protected Jdbi get() {
-        if (jdbi == null) {
-            connect();
-        }
-        return jdbi;
-    }
-
-    private void connect() {
-        MysqlDataSource ds = new MysqlDataSource();
-        ds.setURL("jdbc:mysql://" + DBProperties.host + ":" + DBProperties.port + "/" + DBProperties.dbname);
-        ds.setUser(DBProperties.username);
-        ds.setPassword(DBProperties.password);
-        try {
-            ds.setUseCompression(true);
-            ds.setAutoReconnect(true);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-        jdbi = Jdbi.create(ds);
+        return JdbiProvider.getInstance();
     }
 
 }

--- a/src/main/java/group36/dao/CartItemDAO.java
+++ b/src/main/java/group36/dao/CartItemDAO.java
@@ -91,6 +91,13 @@ public class CartItemDAO extends BaseDao {
                 .execute());
     }
 
+    public int deleteByCartIdWithHandle(org.jdbi.v3.core.Handle h, int cartId) {
+        String sql = "DELETE FROM cart_items WHERE cart_id = :cartId";
+        return h.createUpdate(sql)
+                .bind("cartId", cartId)
+                .execute();
+    }
+
     public int deleteByCartId(int cartId) {
         String sql = "DELETE FROM cart_items WHERE cart_id = :cartId";
         return get().withHandle(handle -> handle.createUpdate(sql)

--- a/src/main/java/group36/dao/DBProperties.java
+++ b/src/main/java/group36/dao/DBProperties.java
@@ -25,13 +25,5 @@ public class DBProperties {
     public static String password = prop.getProperty("db.password");
     public static String dbname = prop.getProperty("db.name");
 
-    public static void main(String[] args) {
-        System.out.println(host);
-        System.out.println(port);
-        System.out.println(username);
-        System.out.println(password);
-        System.out.println(dbname);
-
-    }
 
 }

--- a/src/main/java/group36/dao/FlashSaleDAO.java
+++ b/src/main/java/group36/dao/FlashSaleDAO.java
@@ -86,6 +86,17 @@ public class FlashSaleDAO extends BaseDao {
 
 
 
+        public Optional<FlashSale> findActiveByProductIdWithHandle(org.jdbi.v3.core.Handle h, int productId) {
+                String sql = "SELECT * FROM flash_sales " +
+                                "WHERE product_id = :productId " +
+                                "AND NOW() BETWEEN start_time AND end_time " +
+                                "AND sold_count < stock_limit";
+                return h.createQuery(sql)
+                                .bind("productId", productId)
+                                .map(new FlashSaleMapper())
+                                .findOne();
+        }
+
         public Optional<FlashSale> findActiveByProductId(int productId) {
                 String sql = "SELECT * FROM flash_sales " +
                                 "WHERE product_id = :productId " +
@@ -160,6 +171,14 @@ public class FlashSaleDAO extends BaseDao {
 
 
 
+
+        public int incrementSoldCountWithHandle(org.jdbi.v3.core.Handle h, int flashSaleId, int quantity) {
+                String sql = "UPDATE flash_sales SET sold_count = sold_count + :quantity WHERE id = :id AND sold_count + :quantity <= stock_limit";
+                return h.createUpdate(sql)
+                                .bind("id", flashSaleId)
+                                .bind("quantity", quantity)
+                                .execute();
+        }
 
         public int incrementSoldCount(int id, int increment) {
                 String sql = "UPDATE flash_sales SET sold_count = sold_count + :increment " +

--- a/src/main/java/group36/dao/JdbiProvider.java
+++ b/src/main/java/group36/dao/JdbiProvider.java
@@ -1,0 +1,35 @@
+package group36.dao;
+
+import com.mysql.cj.jdbc.MysqlDataSource;
+import org.jdbi.v3.core.Jdbi;
+
+import java.sql.SQLException;
+
+public class JdbiProvider {
+    private static volatile Jdbi instance;
+
+    public static Jdbi getInstance() {
+        if (instance == null) {
+            synchronized (JdbiProvider.class) {
+                if (instance == null) {
+                    instance = createJdbi();
+                }
+            }
+        }
+        return instance;
+    }
+
+    private static Jdbi createJdbi() {
+        MysqlDataSource ds = new MysqlDataSource();
+        ds.setURL("jdbc:mysql://" + DBProperties.host + ":" + DBProperties.port + "/" + DBProperties.dbname);
+        ds.setUser(DBProperties.username);
+        ds.setPassword(DBProperties.password);
+        try {
+            ds.setUseCompression(true);
+            ds.setAutoReconnect(true);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Jdbi.create(ds);
+    }
+}

--- a/src/main/java/group36/dao/OrderDAO.java
+++ b/src/main/java/group36/dao/OrderDAO.java
@@ -103,10 +103,13 @@ public class OrderDAO extends BaseDao {
         }
 
         public int insert(Order order) {
+                return get().withHandle(h -> insertWithHandle(h, order));
+        }
+
+        public int insertWithHandle(org.jdbi.v3.core.Handle h, Order order) {
                 String sql = "INSERT INTO orders (user_id, address_id, payment_method_id, status, note, admin_note, shipping_fee, total_price) "
-                                +
-                                "VALUES (:userId, :addressId, :paymentMethodId, :status, :note, :adminNote, :shippingFee, :totalPrice)";
-                return get().withHandle(handle -> handle.createUpdate(sql)
+                                + "VALUES (:userId, :addressId, :paymentMethodId, :status, :note, :adminNote, :shippingFee, :totalPrice)";
+                return h.createUpdate(sql)
                                 .bind("userId", order.getUserId())
                                 .bind("addressId", order.getAddressId())
                                 .bind("paymentMethodId", order.getPaymentMethodId())
@@ -117,16 +120,19 @@ public class OrderDAO extends BaseDao {
                                 .bind("totalPrice", order.getTotalPrice())
                                 .executeAndReturnGeneratedKeys("id")
                                 .mapTo(Integer.class)
-                                .one());
+                                .one();
         }
 
         public int insertGuestOrder(Order order) {
+                return get().withHandle(h -> insertGuestOrderWithHandle(h, order));
+        }
+
+        public int insertGuestOrderWithHandle(org.jdbi.v3.core.Handle h, Order order) {
                 String sql = "INSERT INTO orders (user_id, address_id, payment_method_id, status, note, admin_note, " +
                                 "shipping_fee, total_price, guest_email, guest_name, guest_phone) " +
-                                "VALUES (NULL, :addressId, :paymentMethodId, :status, :note, :adminNote, :shippingFee, :totalPrice, "
-                                +
+                                "VALUES (NULL, :addressId, :paymentMethodId, :status, :note, :adminNote, :shippingFee, :totalPrice, " +
                                 ":guestEmail, :guestName, :guestPhone)";
-                return get().withHandle(handle -> handle.createUpdate(sql)
+                return h.createUpdate(sql)
                                 .bind("addressId", order.getAddressId())
                                 .bind("paymentMethodId", order.getPaymentMethodId())
                                 .bind("status", order.getStatus())
@@ -139,7 +145,7 @@ public class OrderDAO extends BaseDao {
                                 .bind("guestPhone", order.getGuestPhone())
                                 .executeAndReturnGeneratedKeys("id")
                                 .mapTo(Integer.class)
-                                .one());
+                                .one();
         }
 
         public int updateStatus(int orderId, String status) {

--- a/src/main/java/group36/dao/OrderDetailDAO.java
+++ b/src/main/java/group36/dao/OrderDetailDAO.java
@@ -67,6 +67,23 @@ public class OrderDetailDAO extends BaseDao {
     
 
 
+    public void insertBatchWithHandle(org.jdbi.v3.core.Handle h, List<OrderDetail> details) {
+        if (details == null || details.isEmpty()) return;
+        String sql = "INSERT INTO order_details (order_id, product_id, variant_id, quantity, unit_price, subtotal) " +
+                "VALUES (:orderId, :productId, :variantId, :quantity, :unitPrice, :subtotal)";
+        var batch = h.prepareBatch(sql);
+        for (OrderDetail detail : details) {
+            batch.bind("orderId", detail.getOrderId())
+                    .bind("productId", detail.getProductId())
+                    .bind("variantId", detail.getVariantId())
+                    .bind("quantity", detail.getQuantity())
+                    .bind("unitPrice", detail.getUnitPrice())
+                    .bind("subtotal", detail.getSubtotal())
+                    .add();
+        }
+        batch.execute();
+    }
+
     public void insertBatch(List<OrderDetail> details) {
         if (details == null || details.isEmpty()) {
             return;

--- a/src/main/java/group36/dao/ProductDAO.java
+++ b/src/main/java/group36/dao/ProductDAO.java
@@ -260,6 +260,14 @@ public class ProductDAO extends BaseDao {
 
 
 
+    public int incrementSoldCountWithHandle(org.jdbi.v3.core.Handle h, int productId, int quantity) {
+        String sql = "UPDATE products SET soild_count = soild_count + :quantity WHERE id = :id";
+        return h.createUpdate(sql)
+                .bind("id", productId)
+                .bind("quantity", quantity)
+                .execute();
+    }
+
     public int incrementSoldCount(int id, int increment) {
         String sql = "UPDATE products SET soild_count = soild_count + :increment WHERE id = :id";
         return get().withHandle(handle -> handle.createUpdate(sql)

--- a/src/main/java/group36/dao/ProductVariantDAO.java
+++ b/src/main/java/group36/dao/ProductVariantDAO.java
@@ -144,6 +144,25 @@ public class ProductVariantDAO extends BaseDao {
 
 
 
+    public int decreaseStockWithLock(org.jdbi.v3.core.Handle h, int id, int quantity) {
+        String lockSql = "SELECT stock FROM product_variants WHERE id = :id FOR UPDATE";
+        Integer currentStock = h.createQuery(lockSql)
+                .bind("id", id)
+                .mapTo(Integer.class)
+                .findOne()
+                .orElseThrow(() -> new IllegalArgumentException("Variant không tồn tại: " + id));
+
+        if (currentStock < quantity) {
+            throw new IllegalArgumentException("Tồn kho không đủ. Còn " + currentStock + ", yêu cầu " + quantity);
+        }
+
+        String updateSql = "UPDATE product_variants SET stock = stock - :quantity WHERE id = :id";
+        return h.createUpdate(updateSql)
+                .bind("id", id)
+                .bind("quantity", quantity)
+                .execute();
+    }
+
     public int decreaseStock(int id, int quantity) {
         String sql = "UPDATE product_variants SET stock = stock - :quantity WHERE id = :id AND stock >= :quantity";
         return get().withHandle(handle -> handle.createUpdate(sql)

--- a/src/main/java/group36/service/OrderService.java
+++ b/src/main/java/group36/service/OrderService.java
@@ -2,6 +2,7 @@ package group36.service;
 
 import group36.dao.*;
 import group36.model.*;
+import org.jdbi.v3.core.Handle;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -83,40 +84,17 @@ public class OrderService {
         double shippingFee = calculateShippingFee(subtotal);
         double totalPrice = subtotal + shippingFee;
 
-        Order order = new Order();
-        order.setUserId(userId);
-        order.setAddressId(addressId);
-        order.setPaymentMethodId(paymentMethodId);
-        order.setNote(note);
-        order.setShippingFee(shippingFee);
-        order.setTotalPrice(totalPrice);
-        order.setStatus(Order.STATUS_PENDING);
-
-        int orderId = orderDAO.insert(order);
-        order.setId(orderId);
-
-        List<OrderDetail> orderDetails = new ArrayList<>();
-        for (CartItem item : cartItems) {
-            OrderDetail detail = OrderDetail.fromCartItem(item, orderId);
-            orderDetails.add(detail);
-        }
-        orderDetailDAO.insertBatch(orderDetails);
-        order.setOrderDetails(orderDetails);
-
-        for (CartItem item : cartItems) {
-            if (item.getVariantId() != null) {
-                productVariantDAO.decreaseStock(item.getVariantId(), item.getQuantity());
-            }
-            productDAO.incrementSoldCount(item.getProductId(), item.getQuantity());
-
-            if (item.hasFlashSalePrice()) {
-                flashSaleDAO.findActiveByProductId(item.getProductId()).ifPresent(fs -> {
-                    flashSaleDAO.incrementSoldCount(fs.getId(), item.getQuantity());
-                });
-            }
-        }
-
-        cartItemDAO.deleteByCartId(cart.getId());
+        Order order = JdbiProvider.getInstance().inTransaction(handle -> {
+            Order o = new Order();
+            o.setUserId(userId);
+            o.setAddressId(addressId);
+            o.setPaymentMethodId(paymentMethodId);
+            o.setNote(note);
+            o.setShippingFee(shippingFee);
+            o.setTotalPrice(totalPrice);
+            o.setStatus(Order.STATUS_PENDING);
+            return executeOrderTransaction(handle, o, cartItems, cart.getId());
+        });
 
         order.setAddress(addressOpt.get());
         order.setPaymentMethod(paymentOpt.get());
@@ -157,38 +135,17 @@ public class OrderService {
         double shippingFee = calculateShippingFee(subtotal);
         double totalPrice = subtotal + shippingFee;
 
-        Order order = new Order();
-        order.setUserId(userId);
-        order.setAddressId(addressId);
-        order.setPaymentMethodId(paymentMethodId);
-        order.setNote(note);
-        order.setShippingFee(shippingFee);
-        order.setTotalPrice(totalPrice);
-        order.setStatus(Order.STATUS_PENDING);
-
-        int orderId = orderDAO.insert(order);
-        order.setId(orderId);
-
-        List<OrderDetail> orderDetails = new ArrayList<>();
-        for (CartItem item : cartItems) {
-            OrderDetail detail = OrderDetail.fromCartItem(item, orderId);
-            orderDetails.add(detail);
-        }
-        orderDetailDAO.insertBatch(orderDetails);
-        order.setOrderDetails(orderDetails);
-
-        for (CartItem item : cartItems) {
-            if (item.getVariantId() != null) {
-                productVariantDAO.decreaseStock(item.getVariantId(), item.getQuantity());
-            }
-            productDAO.incrementSoldCount(item.getProductId(), item.getQuantity());
-
-            if (item.hasFlashSalePrice()) {
-                flashSaleDAO.findActiveByProductId(item.getProductId()).ifPresent(fs -> {
-                    flashSaleDAO.incrementSoldCount(fs.getId(), item.getQuantity());
-                });
-            }
-        }
+        Order order = JdbiProvider.getInstance().inTransaction(handle -> {
+            Order o = new Order();
+            o.setUserId(userId);
+            o.setAddressId(addressId);
+            o.setPaymentMethodId(paymentMethodId);
+            o.setNote(note);
+            o.setShippingFee(shippingFee);
+            o.setTotalPrice(totalPrice);
+            o.setStatus(Order.STATUS_PENDING);
+            return executeOrderTransaction(handle, o, cartItems, null);
+        });
 
         order.setAddress(addressOpt.get());
         order.setPaymentMethod(paymentOpt.get());
@@ -232,45 +189,47 @@ public class OrderService {
         double shippingFee = calculateShippingFee(subtotal);
         double totalPrice = subtotal + shippingFee;
 
-        shippingAddress.setUserId(0);
-        int addressId = addressDAO.insert(shippingAddress);
-        shippingAddress.setId(addressId);
+        Order order = JdbiProvider.getInstance().inTransaction(handle -> {
+            shippingAddress.setUserId(0);
+            int addressId = addressDAO.insertWithHandle(handle, shippingAddress);
+            shippingAddress.setId(addressId);
 
-        Order order = new Order();
-        order.setUserId(null);
-        order.setAddressId(addressId);
-        order.setPaymentMethodId(paymentMethodId);
-        order.setNote(note);
-        order.setShippingFee(shippingFee);
-        order.setTotalPrice(totalPrice);
-        order.setStatus(Order.STATUS_PENDING);
-        order.setGuestEmail(guestInfo.getEmail());
-        order.setGuestName(guestInfo.getFullName());
-        order.setGuestPhone(guestInfo.getPhone());
+            Order o = new Order();
+            o.setUserId(null);
+            o.setAddressId(addressId);
+            o.setPaymentMethodId(paymentMethodId);
+            o.setNote(note);
+            o.setShippingFee(shippingFee);
+            o.setTotalPrice(totalPrice);
+            o.setStatus(Order.STATUS_PENDING);
+            o.setGuestEmail(guestInfo.getEmail());
+            o.setGuestName(guestInfo.getFullName());
+            o.setGuestPhone(guestInfo.getPhone());
 
-        int orderId = orderDAO.insertGuestOrder(order);
-        order.setId(orderId);
+            int orderId = orderDAO.insertGuestOrderWithHandle(handle, o);
+            o.setId(orderId);
 
-        List<OrderDetail> orderDetails = new ArrayList<>();
-        for (CartItem item : cartItems) {
-            OrderDetail detail = OrderDetail.fromCartItem(item, orderId);
-            orderDetails.add(detail);
-        }
-        orderDetailDAO.insertBatch(orderDetails);
-        order.setOrderDetails(orderDetails);
-
-        for (CartItem item : cartItems) {
-            if (item.getVariantId() != null) {
-                productVariantDAO.decreaseStock(item.getVariantId(), item.getQuantity());
+            List<OrderDetail> orderDetails = new ArrayList<>();
+            for (CartItem item : cartItems) {
+                orderDetails.add(OrderDetail.fromCartItem(item, orderId));
             }
-            productDAO.incrementSoldCount(item.getProductId(), item.getQuantity());
+            orderDetailDAO.insertBatchWithHandle(handle, orderDetails);
+            o.setOrderDetails(orderDetails);
 
-            if (item.hasFlashSalePrice()) {
-                flashSaleDAO.findActiveByProductId(item.getProductId()).ifPresent(fs -> {
-                    flashSaleDAO.incrementSoldCount(fs.getId(), item.getQuantity());
-                });
+            for (CartItem item : cartItems) {
+                if (item.getVariantId() != null) {
+                    productVariantDAO.decreaseStockWithLock(handle, item.getVariantId(), item.getQuantity());
+                }
+                productDAO.incrementSoldCountWithHandle(handle, item.getProductId(), item.getQuantity());
+                if (item.hasFlashSalePrice()) {
+                    flashSaleDAO.findActiveByProductIdWithHandle(handle, item.getProductId()).ifPresent(fs -> {
+                        flashSaleDAO.incrementSoldCountWithHandle(handle, fs.getId(), item.getQuantity());
+                    });
+                }
             }
-        }
+
+            return o;
+        });
 
         order.setAddress(shippingAddress);
         order.setPaymentMethod(paymentOpt.get());
@@ -279,6 +238,36 @@ public class OrderService {
             adminNotificationService.createOrderNotification(order);
         } catch (Exception e) {
             e.printStackTrace();
+        }
+
+        return order;
+    }
+
+    private Order executeOrderTransaction(Handle handle, Order order, List<CartItem> cartItems, Integer cartIdToDelete) {
+        int orderId = orderDAO.insertWithHandle(handle, order);
+        order.setId(orderId);
+
+        List<OrderDetail> orderDetails = new ArrayList<>();
+        for (CartItem item : cartItems) {
+            orderDetails.add(OrderDetail.fromCartItem(item, orderId));
+        }
+        orderDetailDAO.insertBatchWithHandle(handle, orderDetails);
+        order.setOrderDetails(orderDetails);
+
+        for (CartItem item : cartItems) {
+            if (item.getVariantId() != null) {
+                productVariantDAO.decreaseStockWithLock(handle, item.getVariantId(), item.getQuantity());
+            }
+            productDAO.incrementSoldCountWithHandle(handle, item.getProductId(), item.getQuantity());
+            if (item.hasFlashSalePrice()) {
+                flashSaleDAO.findActiveByProductIdWithHandle(handle, item.getProductId()).ifPresent(fs -> {
+                    flashSaleDAO.incrementSoldCountWithHandle(handle, fs.getId(), item.getQuantity());
+                });
+            }
+        }
+
+        if (cartIdToDelete != null) {
+            cartItemDAO.deleteByCartIdWithHandle(handle, cartIdToDelete);
         }
 
         return order;


### PR DESCRIPTION
### Mô tả thay đổi
Giải quyết issue #75 liên quan đến lỗi bất đồng bộ (race condition) và thiếu tính toàn vẹn dữ liệu khi thực hiện đặt hàng đồng thời.

Chi tiết các thay đổi đã thực hiện:
- **Quản lý kết nối Database:** Tạo `JdbiProvider` (Singleton) để các DAO chia sẻ chung một kết nối cơ sở dữ liệu thay vì khởi tạo kết nối riêng biệt.
- **Tương thích Transaction:** Cập nhật `BaseDao` và bổ sung các phương thức `WithHandle` trong các DAO liên quan (`AddressDAO`, `CartItemDAO`, `FlashSaleDAO`, `OrderDAO`, `OrderDetailDAO`, `ProductDAO`, `ProductVariantDAO`) để thực thi câu lệnh SQL trong cùng một transaction context.
- **Tránh tranh chấp tồn kho (Race Condition):** Bổ sung khóa bi quan (`FOR UPDATE` thông qua `decreaseStockWithLock`) khi trừ tồn kho của biến thể sản phẩm, tránh lỗi trừ sai số lượng khi nhiều người mua cùng lúc.
- **Đảm bảo tính toàn vẹn:** Bọc toàn bộ quy trình đặt hàng (`createOrder`, `createOrderFromItems`, `createGuestOrder`) trong phương thức `inTransaction()`. Nếu xảy ra lỗi ở bất kỳ bước nào, toàn bộ quá trình sẽ được rollback.
- **Tối ưu mã nguồn:** Gom chung logic xử lý transaction đặt hàng vào phương thức bổ trợ `executeOrderTransaction()`.

- Closes #75